### PR TITLE
Update readme to work around name change issue #7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Sridhar Ratnakumar <srid@srid.ca>"]
 edition = "2018"
-# If you change the name here, you must also do it in flake.nix
+# If you change the name here, you must also do it in flake.nix (and run `cargo generate-lockfile` afterwards)
 name = "rust-nix-template"
 version = "0.1.0"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ See [Nix-ifying Rust projects](https://notes.srid.ca/rust-nix) for details.
 
 ## Adapting this template
 
+- Run `nix develop` to have a working shell ready before name change (Workaround for [an issue](https://github.com/srid/rust-nix-template/issues/7#issuecomment-1097182528)
 - Change `name` in Cargo.toml and flake.nix. Also change `description` in flake.nix.
+- Run `cargo generate-lockfile` in the nix shell
 - There are two CI workflows, and one of them uses Nix which is slower (unless you configure a cache) than the other that is based on rustup. Pick one or the other depending on your trade-offs.
 
 ## Development (Flakes)


### PR DESCRIPTION
I didn't figure out how to do this without a workaround, as after changing the name the nix shell can't be opened:

```
++ crate2nix generate -f ./Cargo.toml -o Cargo-generated.nix -h /nix/store/mizxs1bm2jl30ylq6y2x419n1423ih4r-sonnen-scraper-crate2nix/crate-hashes.json
Error: while retrieving metadata about ./Cargo.toml: Error during execution of `cargo metadata`: error: the lock file /build/jyfdp6r1422lnbdklp6lkbz47l0cqh4k-source/Cargo.lock needs to be updated but --locked was passed to prevent this
```