### PR TITLE
Fix rust-analyzer vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
-        "matklad.rust-analyzer",
+        "rust-lang.rust-analyzer",
         "jnoortheen.nix-ide"
     ]
 }


### PR DESCRIPTION
The extension name has changed.